### PR TITLE
[58465] [WRAPPER] Lower Docker Python bindings version

### DIFF
--- a/starting_package/requirements-core.txt
+++ b/starting_package/requirements-core.txt
@@ -1,3 +1,3 @@
-docker==5.0.0
+docker==4.4.4
 tqdm==4.60.0
 requests==2.22.0

--- a/starting_package/setup.py
+++ b/starting_package/setup.py
@@ -57,7 +57,7 @@ setup(
     license='OSI Approved :: Apache Software License',
     description='DL Workbench is an official UI environment of the OpenVINO™ toolkit.',
     url='https://github.com/openvinotoolkit/workbench_aux',
-    version='2021.4.0.1',
+    version='2021.4.0.2',
     packages=['openvino_workbench'],
     install_requires=REQUIRED_PACKAGES,
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
In order to avoid [this issue](https://github.com/docker/docker-py/issues/2807). 
[Breaking changes](https://github.com/docker/docker-py/releases/tag/5.0.0) that were introduced in the 5.0.0 version do not affect us.